### PR TITLE
Support Fedora, fix netcat selection via NC environment variable

### DIFF
--- a/dhcp.sh
+++ b/dhcp.sh
@@ -93,7 +93,7 @@ fi
 # Handle requests while server is running
 while [[ "$RUNNING" == "1" ]];  do
 	# One netcat handles only one broadcast packet
-	"$NC" -lup 67 -w0 | stdbuf -o0 od -v -w1 -t x1 -An | {
+	"$NC" -ul 67 -w0 | stdbuf -o0 od -v -w1 -t x1 -An | {
 
 		function read_dhcp() {
 			# Read beginning with constant size

--- a/dhcp.sh
+++ b/dhcp.sh
@@ -61,7 +61,7 @@ while getopts "s:m:i:g:l:p:hd" opt; do
 	esac
 done
 
-if [[ $($NC -h 2>&1 | head -1 | grep -q OpenBSD; echo $?) == "1" ]]; then 
+if [[ $("$NC" -w 0 2>&1 | head -1 | grep -q "nvalid.*time"; echo $?) == "0" ]]; then
 	echo "Not supported nc."
 	echo "This solution works only with OpenBSD netcat."
 	echo "Your netcat: $NC"

--- a/dhcp.sh
+++ b/dhcp.sh
@@ -93,7 +93,7 @@ fi
 # Handle requests while server is running
 while [[ "$RUNNING" == "1" ]];  do
 	# One netcat handles only one broadcast packet
-	nc -lup 67 -w0 | stdbuf -o0 od -v -w1 -t x1 -An | {
+	"$NC" -lup 67 -w0 | stdbuf -o0 od -v -w1 -t x1 -An | {
 
 		function read_dhcp() {
 			# Read beginning with constant size
@@ -232,7 +232,7 @@ while [[ "$RUNNING" == "1" ]];  do
 				for i in ${raw_opt[*]}; do
 					printf "\x$i" >> /tmp/dhcp.payload	
 				done
-				cat /tmp/dhcp.payload | nc -ub 255.255.255.255 68 -s $SERVER -p 67 -w0
+				cat /tmp/dhcp.payload | "$NC" -ub 255.255.255.255 68 -s $SERVER -p 67 -w0
 				[[ "$DEBUG" != "1" ]] && rm /tmp/dhcp.payload
 		}
 


### PR DESCRIPTION
Fedora's `netcat-openbsd` does not say it is from OpenBSD, so test for zero timeout support instead. Also it explicitly prohibits `-lp` combination, replace it to more generic `-l [port]`.

Fix that `$NC` is not used for actual connection handling.

P.S.: Please check these don't break other platforms. I have nothing except Fedora right now to test on.